### PR TITLE
feat: lint-staged 기능 추가

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
                 node: true,
                 jest: true,
         },
-        ignorePatterns: ['.eslintrc.js'],
+        ignorePatterns: ['.eslintrc.js', '.prettierrc', '.lintstagedrc'],
         rules: {
                 'prettier/prettier': ['error', { endOfLine: 'auto' }],
                 '@typescript-eslint/interface-name-prefix': 'off',

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -8,6 +8,7 @@ if [ "$current_branch" = "main" ]; then
   exit 1
 fi
 
+# 웹 소켓 모듈 설정으로 임시로 막아놓았습니다. 
 # yarn lint-staged
 
 # =================================================

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,6 @@
+{
+  "*.ts": [
+    "yarn lint",
+    "yarn format"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "is-ci": "^3.0.1",
     "jest": "29.7.0",
     "jira-prepare-commit-msg": "^1.7.2",
+    "lint-staged": "^15.2.0",
     "mime-types": "^2.1.35",
     "nest-winston": "^1.9.4",
     "passport-facebook": "^3.0.0",


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #이슈번호

## ✅ 작업 사항
### lint-staged 의존성 추가
```bash
yarn add -D lint-staged
```

### lint-staged 설정 파일 작성
```json
// .lintstagedrc
{
  "*.ts": [
    "yarn lint",
    "yarn format"
  ]
}
```

### 로컬 환경 테스트 
git commit 명령어 실행시 commitlint 동작전 lint-staged 가 정상적으로 동작하는것을 확인 할 수 있었습니다.
![image](https://github.com/dnd-side-project/dnd-10th-1-backend/assets/58043975/5b8f05d8-6ee4-40bc-927d-7cb736fba030)


## 👩‍💻 공유 포인트 및 논의 사항

### → No staged files match any configured task.
경우에 따라 lint-staged 동작시 해당 문구가 출력될 수 있습니다.
현재는 *.ts 파일이 수정되어 git 의 스테이징 파일 단계에 올라온 경우에 한해서만 lint-staged 가 동작하고 있기에 
해당 문구가 출력된다는것은 git 의 스테이징 파일 단계에 올라온 파일중 *.ts 확장자를 가진 파일이 없다는것을 의미합니다.

![image](https://github.com/dnd-side-project/dnd-10th-1-backend/assets/58043975/203e857a-494e-4caa-ae76-8a32e2de1fce)
