### PR TITLE
Feat: MBTI 목록 조회하기 API 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,9 +7,11 @@ import { EventsModule } from '@/domain/events/events.module';
 import { HealthCheckModule } from '@/domain/health-check/health.module';
 
 import { SharedServiceModule } from '@/shared-service/shared-service.module';
+import { GameMbtiModule } from './domain/game-mbti/game-mbti.module';
+import { GameMbtiService } from './domain/game-mbti/game-mbti.service';
 
 @Module({
-        imports: [HealthCheckModule, SharedServiceModule, EventsModule],
+        imports: [HealthCheckModule, SharedServiceModule, EventsModule, GameMbtiModule],
         controllers: [],
         providers: [
                 {
@@ -17,6 +19,7 @@ import { SharedServiceModule } from '@/shared-service/shared-service.module';
                         useClass: LoggingInterceptor,
                 },
                 Logger,
+                GameMbtiService,
         ],
 })
 export class AppModule {}

--- a/src/domain/game-mbti/game-mbti.controller.spec.ts
+++ b/src/domain/game-mbti/game-mbti.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GameMbtiController } from './game-mbti.controller';
+
+describe('GameMbtiController', () => {
+  let controller: GameMbtiController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GameMbtiController],
+    }).compile();
+
+    controller = module.get<GameMbtiController>(GameMbtiController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/domain/game-mbti/game-mbti.controller.ts
+++ b/src/domain/game-mbti/game-mbti.controller.ts
@@ -1,4 +1,25 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, HttpStatus, Res } from '@nestjs/common';
+import { GameMbtiService } from './game-mbti.service';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
 
-@Controller('game-mbti')
-export class GameMbtiController {}
+@ApiTags('MBTI API')
+@Controller('game/mbti/')
+export class GameMbtiController {
+        constructor(private readonly gameMbtiService: GameMbtiService) {}
+
+        @ApiOperation({
+                summary: 'MBTI 목록 조회하기 API',
+                description: '16가지 MBTI 리스트를 불러옵니다.',
+        })
+        @ApiResponse({
+                status: 200,
+                description: '16가지 MBTI 조회 성공',
+        })
+        @Get('/list')
+        async getMbtiList(@Res() res: Response) {
+                const mbtiList = await this.gameMbtiService.getMbtiList();
+
+                return res.status(HttpStatus.OK).json(mbtiList);
+        }
+}

--- a/src/domain/game-mbti/game-mbti.controller.ts
+++ b/src/domain/game-mbti/game-mbti.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('game-mbti')
+export class GameMbtiController {}

--- a/src/domain/game-mbti/game-mbti.controller.ts
+++ b/src/domain/game-mbti/game-mbti.controller.ts
@@ -16,7 +16,7 @@ export class GameMbtiController {
                 status: 200,
                 description: '16가지 MBTI 조회 성공',
         })
-        @Get('/list')
+        @Get()
         async getMbtiList(@Res() res: Response) {
                 const mbtiList = await this.gameMbtiService.getMbtiList();
 

--- a/src/domain/game-mbti/game-mbti.module.ts
+++ b/src/domain/game-mbti/game-mbti.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { GameMbtiController } from './game-mbti.controller';
+import { GameMbtiService } from './game-mbti.service';
 
 @Module({
-  controllers: [GameMbtiController]
+        providers: [GameMbtiService],
+        controllers: [GameMbtiController],
 })
 export class GameMbtiModule {}

--- a/src/domain/game-mbti/game-mbti.module.ts
+++ b/src/domain/game-mbti/game-mbti.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { GameMbtiController } from './game-mbti.controller';
+
+@Module({
+  controllers: [GameMbtiController]
+})
+export class GameMbtiModule {}

--- a/src/domain/game-mbti/game-mbti.service.spec.ts
+++ b/src/domain/game-mbti/game-mbti.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GameMbtiService } from './game-mbti.service';
+
+describe('GameMbtiService', () => {
+  let service: GameMbtiService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GameMbtiService],
+    }).compile();
+
+    service = module.get<GameMbtiService>(GameMbtiService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/domain/game-mbti/game-mbti.service.ts
+++ b/src/domain/game-mbti/game-mbti.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class GameMbtiService {}

--- a/src/domain/game-mbti/game-mbti.service.ts
+++ b/src/domain/game-mbti/game-mbti.service.ts
@@ -1,4 +1,14 @@
+import { PrismaService } from '@/shared-service/prisma';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class GameMbtiService {}
+export class GameMbtiService {
+        constructor(private readonly prisma: PrismaService) {}
+        async getMbtiList() {
+                const mbtiList = await this.prisma.gameMbti.findMany({
+                        select: { mbti: true },
+                });
+
+                return mbtiList.map((value) => value.mbti);
+        }
+}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
- close #33 

## ✅ 작업 사항
16가지 MBTI 목록을 조회하는 API를 추가하였습니다.
- `/api/v1/game/mbti` 엔드포인트를 생성하여 MBTI 목록을 조회할 수 있습니다.


### Response body
> ![image](https://github.com/dnd-side-project/dnd-10th-1-backend/assets/76420055/06e5cf4d-a8df-4b85-a4ec-eb1ac0226ca6)
배열 타입으로 16가지 mbti를 가져오게 됩니다.


## 👩‍💻 공유 포인트 및 논의 사항