### PR TITLE
Feat: MBTI 입력받기 API 추가 (소켓 적용 전)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,9 +7,11 @@ import { EventsModule } from '@/domain/events/events.module';
 import { HealthCheckModule } from '@/domain/health-check/health.module';
 
 import { SharedServiceModule } from '@/shared-service/shared-service.module';
+import { GameMbtiModule } from './domain/game-mbti/game-mbti.module';
+import { GameMbtiService } from './domain/game-mbti/game-mbti.service';
 
 @Module({
-        imports: [HealthCheckModule, SharedServiceModule, EventsModule],
+        imports: [HealthCheckModule, SharedServiceModule, EventsModule, GameMbtiModule],
         controllers: [],
         providers: [
                 {
@@ -17,6 +19,7 @@ import { SharedServiceModule } from '@/shared-service/shared-service.module';
                         useClass: LoggingInterceptor,
                 },
                 Logger,
+                GameMbtiService,
         ],
 })
 export class AppModule {}

--- a/src/domain/game-mbti/dto/update-mbti.dto.ts
+++ b/src/domain/game-mbti/dto/update-mbti.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsString } from 'class-validator';
+
+export class UpdateUserMbtiDto {
+        @ApiProperty({
+                example: 'ESTJ',
+                description: 'user의 mbti',
+                required: true,
+        })
+        @IsString()
+        mbti: string;
+
+        @ApiProperty({
+                example: 1,
+                description: 'user의 id',
+                required: true,
+        })
+        @IsInt()
+        userId: number;
+}

--- a/src/domain/game-mbti/dto/user-mbti.dto.ts
+++ b/src/domain/game-mbti/dto/user-mbti.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsString } from 'class-validator';
 
-export class UpdateUserMbtiDto {
+export class UserMbtiDto {
         @ApiProperty({
                 example: 'ESTJ',
                 description: 'user의 mbti',

--- a/src/domain/game-mbti/game-mbti.controller.spec.ts
+++ b/src/domain/game-mbti/game-mbti.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GameMbtiController } from './game-mbti.controller';
+
+describe('GameMbtiController', () => {
+  let controller: GameMbtiController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [GameMbtiController],
+    }).compile();
+
+    controller = module.get<GameMbtiController>(GameMbtiController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/domain/game-mbti/game-mbti.controller.ts
+++ b/src/domain/game-mbti/game-mbti.controller.ts
@@ -1,4 +1,25 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, HttpStatus, Res } from '@nestjs/common';
+import { GameMbtiService } from './game-mbti.service';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
 
-@Controller('game-mbti')
-export class GameMbtiController {}
+@ApiTags('MBTI API')
+@Controller('game/mbti/')
+export class GameMbtiController {
+        constructor(private readonly gameMbtiService: GameMbtiService) {}
+
+        @ApiOperation({
+                summary: 'MBTI 목록 조회하기 API',
+                description: '16가지 MBTI 리스트를 불러옵니다.',
+        })
+        @ApiResponse({
+                status: 200,
+                description: '16가지 MBTI 조회 성공',
+        })
+        @Get('/list')
+        async getMbtiList(@Res() res: Response) {
+                const mbtiList = await this.gameMbtiService.getMbtiList();
+
+                return res.status(HttpStatus.OK).json(mbtiList);
+        }
+}

--- a/src/domain/game-mbti/game-mbti.controller.ts
+++ b/src/domain/game-mbti/game-mbti.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, HttpStatus, Res } from '@nestjs/common';
+import { Body, Controller, Get, HttpStatus, Post, Res } from '@nestjs/common';
 import { GameMbtiService } from './game-mbti.service';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
+import { UpdateUserMbtiDto } from './dto/update-mbti.dto';
 
 @ApiTags('MBTI API')
 @Controller('game/mbti/')
@@ -21,5 +22,19 @@ export class GameMbtiController {
                 const mbtiList = await this.gameMbtiService.getMbtiList();
 
                 return res.status(HttpStatus.OK).json(mbtiList);
+        }
+
+        @ApiOperation({
+                summary: 'MBTI 입력받기 API',
+                description: '사용자의 MBTI를 입력 받습니다.',
+        })
+        @ApiResponse({
+                status: 200,
+                description: '사용자의 MBTI 입력 받아오기 성공',
+        })
+        @Post()
+        getUserMbti(@Body() updateUserMbtiDto: UpdateUserMbtiDto) {
+                const { mbti, userId } = updateUserMbtiDto;
+                return this.gameMbtiService.getUserMbti(userId, mbti);
         }
 }

--- a/src/domain/game-mbti/game-mbti.controller.ts
+++ b/src/domain/game-mbti/game-mbti.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('game-mbti')
+export class GameMbtiController {}

--- a/src/domain/game-mbti/game-mbti.controller.ts
+++ b/src/domain/game-mbti/game-mbti.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Get, HttpStatus, Post, Res } from '@nestjs/common';
 import { GameMbtiService } from './game-mbti.service';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
-import { UpdateUserMbtiDto } from './dto/update-mbti.dto';
+import { UserMbtiDto } from './dto/user-mbti.dto';
 
 @ApiTags('MBTI API')
 @Controller('game/mbti/')
@@ -33,8 +33,8 @@ export class GameMbtiController {
                 description: '사용자의 MBTI 입력 받아오기 성공',
         })
         @Post()
-        getUserMbti(@Body() updateUserMbtiDto: UpdateUserMbtiDto) {
-                const { mbti, userId } = updateUserMbtiDto;
-                return this.gameMbtiService.getUserMbti(userId, mbti);
+        UpdateUserMbti(@Body() UserMbtiDto: UserMbtiDto) {
+                const { mbti, userId } = UserMbtiDto;
+                return this.gameMbtiService.UpdateUserMbti(userId, mbti);
         }
 }

--- a/src/domain/game-mbti/game-mbti.controller.ts
+++ b/src/domain/game-mbti/game-mbti.controller.ts
@@ -16,7 +16,7 @@ export class GameMbtiController {
                 status: 200,
                 description: '16가지 MBTI 조회 성공',
         })
-        @Get('/list')
+        @Get()
         async getMbtiList(@Res() res: Response) {
                 const mbtiList = await this.gameMbtiService.getMbtiList();
 

--- a/src/domain/game-mbti/game-mbti.module.ts
+++ b/src/domain/game-mbti/game-mbti.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { GameMbtiController } from './game-mbti.controller';
+import { GameMbtiService } from './game-mbti.service';
 
 @Module({
-  controllers: [GameMbtiController]
+        providers: [GameMbtiService],
+        controllers: [GameMbtiController],
 })
 export class GameMbtiModule {}

--- a/src/domain/game-mbti/game-mbti.module.ts
+++ b/src/domain/game-mbti/game-mbti.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { GameMbtiController } from './game-mbti.controller';
+
+@Module({
+  controllers: [GameMbtiController]
+})
+export class GameMbtiModule {}

--- a/src/domain/game-mbti/game-mbti.service.spec.ts
+++ b/src/domain/game-mbti/game-mbti.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GameMbtiService } from './game-mbti.service';
+
+describe('GameMbtiService', () => {
+  let service: GameMbtiService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [GameMbtiService],
+    }).compile();
+
+    service = module.get<GameMbtiService>(GameMbtiService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/domain/game-mbti/game-mbti.service.ts
+++ b/src/domain/game-mbti/game-mbti.service.ts
@@ -12,7 +12,7 @@ export class GameMbtiService {
                 return mbtiList.map((value) => value.mbti);
         }
 
-        async getUserMbti(userId: number, mbti: string) {
+        async UpdateUserMbti(userId: number, mbti: string) {
                 const updateUser = await this.prismaService.user.update({
                         where: { id: userId },
                         data: { mbti: mbti },

--- a/src/domain/game-mbti/game-mbti.service.ts
+++ b/src/domain/game-mbti/game-mbti.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class GameMbtiService {}

--- a/src/domain/game-mbti/game-mbti.service.ts
+++ b/src/domain/game-mbti/game-mbti.service.ts
@@ -3,12 +3,21 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class GameMbtiService {
-        constructor(private readonly prisma: PrismaService) {}
+        constructor(private readonly prismaService: PrismaService) {}
         async getMbtiList() {
-                const mbtiList = await this.prisma.gameMbti.findMany({
+                const mbtiList = await this.prismaService.gameMbti.findMany({
                         select: { mbti: true },
                 });
 
                 return mbtiList.map((value) => value.mbti);
+        }
+
+        async getUserMbti(userId: number, mbti: string) {
+                const updateUser = await this.prismaService.user.update({
+                        where: { id: userId },
+                        data: { mbti: mbti },
+                });
+
+                return updateUser.mbti;
         }
 }

--- a/src/domain/game-mbti/game-mbti.service.ts
+++ b/src/domain/game-mbti/game-mbti.service.ts
@@ -1,4 +1,14 @@
+import { PrismaService } from '@/shared-service/prisma';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
-export class GameMbtiService {}
+export class GameMbtiService {
+        constructor(private readonly prisma: PrismaService) {}
+        async getMbtiList() {
+                const mbtiList = await this.prisma.gameMbti.findMany({
+                        select: { mbti: true },
+                });
+
+                return mbtiList.map((value) => value.mbti);
+        }
+}


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->
#34 

## ✅ 작업 사항
소켓을 적용하기 전, MBTI 입력 받는 API를 추가하였습니다.
`/api/v1/game/mbti` 엔드포인트의 POST 방식으로 사용자의 MBTI를 입력 받을 수 있습니다.
![image](https://github.com/dnd-side-project/dnd-10th-1-backend/assets/76420055/3097fcca-e585-47c8-8bac-da8fe10d21a4)


## 👩‍💻 공유 포인트 및 논의 사항
소켓 세부 명세가 정해지면 추가 작업이 들어갈 예정입니다.