### PR TITLE
Feat(domain): 방 폭파 기능 및 게임 시작 기능에 대하여 프론트 소켓 요청 처리 완료

### DIFF
--- a/src/domain/game/game.gateway.ts
+++ b/src/domain/game/game.gateway.ts
@@ -68,10 +68,9 @@ export class GameEventsGateway implements OnGatewayInit, OnGatewayConnection, On
                         });
 
                         const gameInfo = await this.gameService.findOneBlankTopic(randomNum);
-                        this.server.to(roomId).emit(GameEvent.GET_GAME_ITEM, gameInfo);
+                        this.server.to(roomId).emit(GameEvent.MOVE_TO_GAME, { gameId, gameInfo });
+                        // this.server.to(roomId).emit(GameEvent.GET_GAME_ITEM, gameInfo);
                 }
-
-                this.server.to(roomId).emit(GameEvent.MOVE_TO_GAME);
         }
 
         // game - 게임 종료
@@ -94,8 +93,11 @@ export class GameEventsGateway implements OnGatewayInit, OnGatewayConnection, On
                                 },
                         );
 
-                        this.server.in(roomId).socketsLeave(roomId);
+                        // this.server.in(roomId).socketsLeave(roomId);
                         this.server.in(roomId).disconnectSockets(true);
+
+                        this.server.to(roomId).emit(RoomEvent.DISCONNECT_ALL_SOCKET);
+
                         return;
                 }
 

--- a/src/domain/room/types/events/room-event.enum.ts
+++ b/src/domain/room/types/events/room-event.enum.ts
@@ -24,6 +24,12 @@ export enum RoomEvent {
         JOIN_ROOM = 'join-room',
 
         /**
+         * @event room - 방 폭파 이벤트
+         * @description 방장이 퇴장하면서 개설했던 방이 폭파됩니다. 방에 속했던 유저들은 모두 소켓이 끊어집니다.
+         * */
+        DISCONNECT_ALL_SOCKET = 'disconnect-all-socket',
+
+        /**
          * @event room - 대기실 이벤트
          * @description 대기실의 사용자 상태 정보를 갱신 합니다. ( 입장/준비 완료/퇴장 )
          * */


### PR DESCRIPTION
<!-- PR 제목은 커밋 메세지 컨벤션 형식으로 작성해주세요 ex) feat: 메인페이지 UI 구현, fix: 로딩관련 예외처리 구현 -->

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #이슈번호

## ✅ 작업 사항
방 폭파 기능 및 게임 시작 기능에 대하여 프론트 소켓 요청 처리 완료

## 👩‍💻 공유 포인트 및 논의 사항
1. `MOVE_TO_GAME` 이벤트에 `gameId`와 `gameInfo` 를 붙여서 보냈습니다.
2. 방장이 퇴장한 경우, 같은 방에 속했던 모든 소켓들을 끊고 있습니다.`DISCONNECT_ALL_SOCKET` 이라는 새로운 소켓 이벤트를 생성해서 emit 하였습니다. 프론트 측에서 해당 소켓을 받으면 메인 화면으로 이동한다고 합니다.